### PR TITLE
Fixing bug reading two parameters

### DIFF
--- a/ApiManagementSchemaImport/Microsoft.Azure.ApiManagement.WsdlProcessor.App/Program.cs
+++ b/ApiManagementSchemaImport/Microsoft.Azure.ApiManagement.WsdlProcessor.App/Program.cs
@@ -20,25 +20,17 @@ namespace Microsoft.Azure.ApiManagement.WsdlProcessor.App
                 wsdlFile = args[0];
                 wsdlFile = wsdlFile.Contains(".wsdl") ? wsdlFile : wsdlFile + ".wsdl";
                 outputFile = args[1];
-                outputFile = outputFile.Contains(".wsdl") ? outputFile : outputFile + ".wsdl";
                 outputFile = Path.IsPathRooted(outputFile) ? outputFile : Path.Join(Directory.GetCurrentDirectory(), outputFile);
-                var attr = File.GetAttributes(outputFile);
-                if (attr.HasFlag(FileAttributes.Directory))
-                {
-                    Console.WriteLine("Second parameter should be a file, not a directory.");
-                    return;
-                }
             }
             else
             {
-                Console.WriteLine("Please enter a wsdl file to process and output folder.");
+                Console.WriteLine("Please enter a wsdl file to process and output file.");
                 return;
             }
             var wsdlString = File.ReadAllText(wsdlFile);
             var xDocument = XDocument.Parse(wsdlString);
             await WsdlDocument.LoadAsync(xDocument.Root, log);
             xDocument.Root.Save(outputFile);
-            //Directory.GetCurrentDirectory();
         }
     }
 


### PR DESCRIPTION
## Purpose
Fixing bug reading two parameters for WsdlProcessor

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```