### PR TITLE
Correct Path to WSDLProcessor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The Powershell script **batchXmlSchemaProcessor.ps1** provides the following fea
 
         git clone https://github.com/Azure-Samples/api-management-schema-import.git
         
-        cd api-management-schema-import/Mcrosoft.Azure.ApiManagement.WsdlProcessor.App 
+        cd api-management-schema-import/ApiManagementSchemaImport/Microsoft.Azure.ApiManagement.WsdlProcessor.App 
 
 
 1. Restore the packages that are specified in the .csproj file of the project:


### PR DESCRIPTION
## Purpose
The README instructions for running the WSDLProcessor include incorrect path to the project folder. This corrects the path in the cd command.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/Azure-Samples/api-management-schema-import.git
```

* Test the code
Run the code samples in the 'Run WSDLProcessor' of the README in CMD.
```

## What to Check
Ensure the steps take you to the correct project directory and allow you to build it.